### PR TITLE
Adding support of ESP32 (when used with platformio)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Ultra Low Power 3D accelerometer.
 paragraph=This library provides Arduino support for the Ultra Low Power 3D accelerometer LIS2DW12 for STM32 boards.
 category=Sensors
 url=https://github.com/stm32duino/LIS2DW12
-architectures=stm32, avr, sam
+architectures=stm32, avr, sam, esp32

--- a/src/LIS2DW12Sensor.h
+++ b/src/LIS2DW12Sensor.h
@@ -44,7 +44,7 @@
 
 
 /* Includes ------------------------------------------------------------------*/
-
+#include <Arduino.h>
 #include "Wire.h"
 #include "SPI.h"
 #include "lis2dw12_reg.h"


### PR DESCRIPTION
Without the `Arduino` header, PlatformIO will complain about an undefined `MSBFIRST`!